### PR TITLE
Customize the generator for MkDocs-specific needs

### DIFF
--- a/src/best_of/default_config.py
+++ b/src/best_of/default_config.py
@@ -42,6 +42,11 @@ def prepare_configuration(cfg: dict) -> Dict:
 
     if "generate_install_hints" not in config:
         config.generate_install_hints = True
+    elif "generate_clone_hints" not in config:
+        config.generate_clone_hints = config.generate_install_hints
+
+    if "generate_clone_hints" not in config:
+        config.generate_clone_hints = False
 
     if "generate_toc" not in config:
         config.generate_toc = True

--- a/src/best_of/default_config.py
+++ b/src/best_of/default_config.py
@@ -59,7 +59,7 @@ def prepare_configuration(cfg: dict) -> Dict:
         config.hide_empty_categories = False
 
     if "max_description_length" not in config:
-        config.max_description_length = 55
+        config.max_description_length = 100
 
     if "min_description_length" not in config:
         config.min_description_length = MIN_PROJECT_DESC_LENGTH

--- a/src/best_of/generators/markdown_list.py
+++ b/src/best_of/generators/markdown_list.py
@@ -353,9 +353,7 @@ def generate_category_md(
             + " hidden projects...</summary>\n\n"
         )
         for project in category.hidden_projects:
-            project_md = generate_project_md(
-                project, config, labels, generate_body=False
-            )
+            project_md = generate_project_md(project, config, labels)
             category_md += project_md + "\n"
         category_md += "</details>\n"
 

--- a/src/best_of/generators/markdown_list.py
+++ b/src/best_of/generators/markdown_list.py
@@ -229,7 +229,11 @@ def generate_project_body(project: Dict, configuration: Dict, labels: list) -> s
 
     for package_manager in integrations.AVAILABLE_PACKAGE_MANAGER:
         package_manager_id = package_manager.name.lower().strip() + "_id"
-        if package_manager_id in project and project[package_manager_id]:
+        if (
+            package_manager_id in project
+            and project[package_manager_id]
+            or package_manager.name == "mkdocs"
+        ):
             body_md += package_manager.generate_md_details(project, configuration)
 
     if not body_md:

--- a/src/best_of/generators/markdown_list.py
+++ b/src/best_of/generators/markdown_list.py
@@ -83,12 +83,10 @@ def generate_metrics_info(project: Dict, configuration: Dict) -> str:
         metrics_md = status_md
 
     if metrics_md:
-        # add divider if metrics are available
-        metrics_md = "(" + metrics_md + ")"
         # remove unneccesary whitespaces
         utils.clean_whitespaces(metrics_md)
-        # Add whitespace
-        metrics_md = metrics_md + " "
+        # add divider if metrics are available
+        metrics_md = " - " + metrics_md
 
     return metrics_md
 
@@ -153,8 +151,8 @@ def generate_project_labels(project: Dict, labels: list) -> Tuple[str, int]:
             label_md = '<a href="' + label_info.url + '">' + label_md + "</a>"
 
         if label_md:
-            # Add a single space in front of label:
-            labels_md += " " + label_md.strip()
+            # Add a separator between labels:
+            labels_md += " · " + label_md.strip()
             labels_text_length += LABEL_SPACING_LENGTH
 
     return (labels_md, labels_text_length)
@@ -200,7 +198,7 @@ def generate_license_info(project: Dict, configuration: Dict) -> Tuple[str, int]
             license_md += " <code>Unlicensed</code>"
         else:
             license_md += " <code>❗Unlicensed</code>"
-    return license_md, license_length
+    return " ·" + license_md, license_length
 
 
 def generate_project_body(project: Dict, configuration: Dict, labels: list) -> str:
@@ -258,7 +256,6 @@ def generate_project_md(
 
     metadata_md = ""
     if license_md and labels_md:
-        # TODO: add " · " in between?
         metadata_md = license_md + labels_md
     elif license_md:
         metadata_md = license_md
@@ -276,33 +273,17 @@ def generate_project_md(
     if project.labels:
         label_count = len(project.labels)
 
-    if license_len:
-        # Add spacing to length
-        license_len += 2
-
-    desc_length = int(
-        round(
-            max(
-                configuration.max_description_length,
-                105
-                - (len(project.name) * 1.3)
-                - len(metrics_md)
-                - license_len
-                - (label_count * 5),
-            )
-        )
-    )
     description = utils.process_description(
         project.description,
-        desc_length,
+        configuration.max_description_length,
         ascii_only=configuration.ascii_description,
     )
 
     # target="_blank"
+    if description:
+        description = f"<br>{description}"
     if project.resource:
-        if description:
-            description = f"- {description}"
-        project_md = '🔗&nbsp;<b><a href="{homepage}">{name}</a></b> {metrics} {description}{metadata}\n'.format(
+        project_md = '🔗&nbsp;<b><a href="{homepage}">{name}</a></b> {metrics}{metadata}{description}\n'.format(
             homepage=project.homepage,
             name=project.name,
             description=description,
@@ -310,7 +291,7 @@ def generate_project_md(
             metadata=metadata_md,
         )
     elif generate_body:
-        project_md = '<details><summary><b><a href="{homepage}">{name}</a></b> {metrics}- {description}{metadata}</summary>{body}</details>'.format(
+        project_md = '<details><summary><b><a href="{homepage}">{name}</a></b> {metrics}{metadata}{description}</summary>{body}</details>'.format(
             homepage=project.homepage,
             name=project.name,
             description=description,
@@ -320,7 +301,7 @@ def generate_project_md(
         )
     else:
         # don't use details format
-        project_md = '- <b><a href="{homepage}">{name}</a></b> {metrics}- {description}{metadata}'.format(
+        project_md = '- <b><a href="{homepage}">{name}</a></b> {metrics}{metadata}{description}'.format(
             homepage=project.homepage,
             name=project.name,
             description=description,

--- a/src/best_of/integrations/__init__.py
+++ b/src/best_of/integrations/__init__.py
@@ -8,6 +8,7 @@ from best_of.integrations import (
     gitlab_integration,
     go_integration,
     maven_integration,
+    mkdocs_integration,
     npm_integration,
     pypi_integration,
 )
@@ -23,6 +24,7 @@ AVAILABLE_PACKAGE_MANAGER: List[base_integration.BaseIntegration] = [
     dockerhub_integration.DockerhubIntegration(),
     cargo_integration.CargoIntegration(),
     go_integration.GoIntegration(),
+    mkdocs_integration.MkDocsIntegration(),
 ]
 
 # TODO: "helm_id", "brew_id", "apt_id", "yum_id", "snap_id", "dnf_id", "yay_id",

--- a/src/best_of/integrations/github_integration.py
+++ b/src/best_of/integrations/github_integration.py
@@ -564,12 +564,12 @@ def generate_github_details(project: Dict, configuration: Dict) -> str:
     seperator = (
         ""
         if not configuration.generate_badges
-        and not configuration.generate_install_hints
+        and not configuration.generate_clone_hints
         else ":"
     )
 
     details_md = "- [GitHub](" + github_url + ")" + metrics_md + seperator + "\n"
 
-    if configuration.generate_install_hints:
+    if configuration.generate_clone_hints:
         details_md += "\n\t```\n\tgit clone https://github.com/{github_id}\n\t```\n"
     return details_md.format(github_id=github_id)

--- a/src/best_of/integrations/gitlab_integration.py
+++ b/src/best_of/integrations/gitlab_integration.py
@@ -225,13 +225,13 @@ class GitLabIntegration(BaseIntegration):
         separator = (
             ""
             if not configuration.generate_badges
-            and not configuration.generate_install_hints
+            and not configuration.generate_clone_hints
             else ":"
         )
 
         details_md = f"- [GitLab]({project.gitlab_url}) {metrics_md}{separator}\n"
 
-        if configuration.generate_install_hints:
+        if configuration.generate_clone_hints:
             details_md += f"\n\t```\n\tgit clone {project.gitlab_url}\n\t```\n"
 
         return details_md

--- a/src/best_of/integrations/mkdocs_integration.py
+++ b/src/best_of/integrations/mkdocs_integration.py
@@ -1,0 +1,54 @@
+from addict import Dict
+
+from best_of.integrations.base_integration import BaseIntegration
+
+
+def _get_as_list(mapping, key):
+    names = mapping.get(key, ())
+    if isinstance(names, str):
+        names = (names,)
+    return names
+
+
+class MkDocsIntegration(BaseIntegration):
+    @property
+    def name(self) -> str:
+        return "mkdocs"
+
+    def update_project_info(self, project_info: Dict) -> None:
+        pass
+
+    def generate_md_details(self, project: Dict, configuration: Dict) -> str:
+        if not configuration.generate_install_hints:
+            return ""
+
+        themes = _get_as_list(project, "mkdocs_theme")
+        plugins = _get_as_list(project, "mkdocs_plugin")
+        extensions = _get_as_list(project, "markdown_extension")
+
+        config_keys = []
+        yml = []
+        if themes:
+            config_keys.append("theme")
+            yml += [f"theme: {x}" for x in themes]
+        if plugins:
+            config_keys.append("plugins")
+            theme_prefix = f"{themes[0]}/" if themes else ""
+            yml += ["plugins:"] + [
+                f"  - {x.removeprefix(theme_prefix)}" for x in plugins
+            ]
+        if extensions:
+            config_keys.append("markdown_extensions")
+            yml += ["markdown_extensions:"] + [f"  - {x}" for x in extensions]
+
+        if not config_keys:
+            return ""
+        url = f"https://www.mkdocs.org/user-guide/configuration/#{config_keys[0]}"
+
+        lines = [
+            f"Add to [mkdocs.yml]({url}):",
+            "```yaml",
+            *yml,
+            "```",
+        ]
+        return "- " + "".join(f"   {line}\n" for line in lines).lstrip()


### PR DESCRIPTION
- Edit the output style to match the preference for MkDocs
  Replaces postprocessing at https://github.com/mkdocs/catalog/blob/57f05e34859a68b47710a7e387c19bf6f1245eed/reformat.py
- Stop printing out GitHub clone commands
- Also include details for hidden projects
- Print instructions for adding to mkdocs.yml

Preview: https://github.com/mkdocs/catalog/tree/preview

@pawamoy