### PR TITLE
fix: handle urllib3.HTTPError for pypistats 429 rate limiting

### DIFF
--- a/src/best_of/integrations/pypi_integration.py
+++ b/src/best_of/integrations/pypi_integration.py
@@ -6,6 +6,7 @@ import pypistats
 from addict import Dict
 from httpx import HTTPStatusError
 from requests.exceptions import HTTPError
+from urllib3.exceptions import HTTPError as Urllib3HTTPError
 
 from best_of import utils
 from best_of.integrations import libio_integration
@@ -104,9 +105,10 @@ class PypiIntegration(BaseIntegration):
                 project_info.monthly_downloads += int(
                     project_info.pypi_monthly_downloads
                 )
+                time.sleep(2)  # respect pypistats 30 req/min limit
                 return
-            except (HTTPError, HTTPStatusError) as ex:
-                if ex.response.status_code == 429:
+            except (HTTPError, HTTPStatusError, Urllib3HTTPError) as ex:
+                if getattr(getattr(ex, 'response', None), 'status_code', None) == 429 or '429' in str(ex):
                     sleep_time = 2 * i
                     log.info(
                         f"Too many requests to pypistats (429). Sleep for {sleep_time} seconds and try again."


### PR DESCRIPTION
pypistats internally uses urllib3 and raises `urllib3.exceptions.HTTPError` for HTTP 429 responses, but the except clause was only catching `requests.exceptions.HTTPError` and `httpx.HTTPStatusError`. As a result, 429 errors fell through to the generic `Exception` handler and were **discarded instead of being retried**.

### Changes
1. **Catch `urllib3.exceptions.HTTPError`** in the retry except clause
2. **Safe 429 detection** — `urllib3.HTTPError` doesn't have a `.response` attribute, so fall back to string matching on `'429' in str(ex)`
3. **Add 2s delay between successful requests** — pypistats.org has a 30 req/min limit; with many projects this prevents perpetual 429 backoff cycles

Fixes the repeated warnings seen in CI:
```
urllib3.exceptions.HTTPError: HTTP Error 429 for url: https://pypistats.org/...
```